### PR TITLE
Workaround for Monterey random crash

### DIFF
--- a/src/osax/payload.m
+++ b/src/osax/payload.m
@@ -726,6 +726,7 @@ static void do_window_shadow(const char *message)
     } else {
         CGSSetWindowTags(_connection, wid, tags, 32);
     }
+    if (__builtin_available(macOS 12.0, *)) return;
     CGSInvalidateWindowShadow(_connection, wid);
 }
 


### PR DESCRIPTION
`CGSInvalidateWindowShadow` causes some random crashes, temporarily disable it on Monterey.